### PR TITLE
typo fix, remove need for installation everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All following files are named as uuid-1, uuid-2, ...
 
 Currently, there are no prebuilt packages, but Ubuntu 12.04 and CentOS6.5 have been successfully tested.
 
-Prequesites for Ubuntu:
+Prerequisites for Ubuntu:
 
 ```
 apt-get install uuid-dev libssl-dev build-essential
@@ -51,8 +51,6 @@ cd irods_resource_plugin_rados
 make
 make install
 ```
-
-The plugin needs to be present on both, the iCAT server and the resource server.
 
 ## Setup
 


### PR DESCRIPTION
The impostor resource removes the need to have a resource plugin installed on all servers in the Zone.

Issue: https://github.com/irods/irods/issues/2186
Commit: https://github.com/irods/irods/commit/71d0728ae3
